### PR TITLE
Fix node 4.x back compatibility

### DIFF
--- a/lib/data.lib.js
+++ b/lib/data.lib.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class DataOperations {
     static fieldEmpty(fieldArray) {
 

--- a/lib/dukpt.lib.js
+++ b/lib/dukpt.lib.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const DataOperations = require('./data.lib');
 
 class Dukpt {
@@ -7,8 +9,8 @@ class Dukpt {
         this._sessionKey = this._deriveDukptSessionKey();
     }
 
-    _deriveDukptSessionKey(keyMode = 'datakey') {
-
+    _deriveDukptSessionKey(keyMode) {
+        keyMode = keyMode || 'datakey';
         const dBDK = this.bdk;
         const dKSN = this.ksn;
 


### PR DESCRIPTION
Fixes `SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode"` error and default value error occuring in node 4.x